### PR TITLE
Fill out config file

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,6 @@
 {
     "title": "conda-forge status",
     "logo": "icon.png",
-    "favicon": "icon.png"
+    "favicon": "icon.png",
+    "footer": "Status page for <a href='https://conda-forge.github.io'>conda-forge</a>, generated with <a href='https://github.com/jayfk/statuspage'>jayfk/statuspage</a>."
 }


### PR DESCRIPTION
Fill out the rest of the `config.json` to hopefully regenerate the status page with the org icon.

xref: https://github.com/conda-forge/status/pull/28