### PR TITLE
ENH add webservices and azure

### DIFF
--- a/azure.js
+++ b/azure.js
@@ -1,0 +1,28 @@
+function loadAzureStatusJSON (url, callback) {
+  var xobj = new XMLHttpRequest()
+  xobj.overrideMimeType('application/json')
+  xobj.open('GET', url, true)
+  xobj.onreadystatechange = function () {
+    if (xobj.readyState === 4 && xobj.status === 200) {
+      // Required use of an anonymous callback as .open will NOT return a value
+      // but simply returns undefined in asynchronous mode
+      callback(xobj.responseText)
+    }
+  }
+  xobj.send(null)
+}
+
+function displayAzureStatus (reportText) {
+  var report = JSON.parse(reportText)
+  var div = document.getElementById('azure-status')
+  div.innerHTML = report.azure
+
+  if (report.azure === 'Everything is looking good') {
+    div.className = 'status operational'
+  } else {
+    div.className = 'status degraded performance'
+  }
+}
+
+var url = 'https://conda-forge-status-monitor.herokuapp.com/status'
+loadAzureStatusJSON(url, displayAzureStatus)

--- a/index.html
+++ b/index.html
@@ -75,6 +75,12 @@
           </h5>
         </div>
 
+        <div class="webservices">
+          <h5><a href="https://github.com/conda-forge/conda-forge-webservices">admin web services</a> status:
+              <span id="webservices-status">No Status Available</span></h5>
+          <script type="text/javascript" src="linter.js"></script>
+        </div>
+
         <div class="cloning">
             <h5><a href=https://conda-static.anaconda.org/conda-forge/rss.xml>CDN cloning</a> status:
                 <span class="cdn-status status operational">operational</span></h5>
@@ -118,6 +124,10 @@
         <div id="ciStatusDiv-circle"><h5><a href="https://status.circleci.com">CircleCI status</a>: No Status Available</h5></div>
         <div id="ciStatusDiv-appveyor"><h5><a href="https://status.appveyor.com">AppVeyor status</a>: No Status Available</h5></div>
         <script type="text/javascript" src="cistatus.js"></script>
+        <div id="azure">
+          <h5><a href="https://status.dev.azure.com/">Azure DevOps</a>: <span id="azure-status">No Status Available</span></h5>
+        </div>
+        <script type="text/javascript" src="azure.js"></script>
 
         <!-- <h4 data-l10n-id="systems">Systems</h4>
         <ul class="systems">

--- a/linter.js
+++ b/linter.js
@@ -1,0 +1,28 @@
+function loadStatusBotJSON (url, callback) {
+  var xobj = new XMLHttpRequest()
+  xobj.overrideMimeType('application/json')
+  xobj.open('GET', url, true)
+  xobj.onreadystatechange = function () {
+    if (xobj.readyState === 4 && xobj.status === 200) {
+      // Required use of an anonymous callback as .open will NOT return a value
+      // but simply returns undefined in asynchronous mode
+      callback(xobj.responseText)
+    }
+  }
+  xobj.send(null)
+}
+
+function displayStatusBot (reportText) {
+  var report = JSON.parse(reportText)
+  var div = document.getElementById('webservices-status')
+  div.innerHTML = report.webservices
+
+  if (report.webservices === 'operational') {
+    div.className = 'status operational'
+  } else {
+    div.className = 'status degraded performance'
+  }
+}
+
+var url = 'https://conda-forge-status-monitor.herokuapp.com/status'
+loadStatusBotJSON(url, displayStatusBot)

--- a/template.html
+++ b/template.html
@@ -86,6 +86,12 @@
           </h5>
         </div>
 
+        <div class="webservices">
+          <h5><a href="https://github.com/conda-forge/conda-forge-webservices">admin web services</a> status:
+              <span id="webservices-status">No Status Available</span></h5>
+          <script type="text/javascript" src="linter.js"></script>
+        </div>
+
         <div class="cloning">
             <h5><a href=https://conda-static.anaconda.org/conda-forge/rss.xml>CDN cloning</a> status:
                 <span class="cdn-status status operational">operational</span></h5>
@@ -129,7 +135,10 @@
         <div id="ciStatusDiv-circle"><h5><a href="https://status.circleci.com">CircleCI status</a>: No Status Available</h5></div>
         <div id="ciStatusDiv-appveyor"><h5><a href="https://status.appveyor.com">AppVeyor status</a>: No Status Available</h5></div>
         <script type="text/javascript" src="cistatus.js"></script>
-
+        <div id="azure">
+          <h5><a href="https://status.dev.azure.com/">Azure DevOps</a>: <span id="azure-status">No Status Available</span></h5>
+        </div>
+        <script type="text/javascript" src="azure.js"></script>
         <!-- <h4 data-l10n-id="systems">Systems</h4>
         <ul class="systems">
           {% for system, data in systems.items() %}


### PR DESCRIPTION
Alright! This is the last status page PR for a while I hope. This one adds azure and the web services bot. I am querying the bot update_me endpoint w/ a ping, and it if takes more than a second to respond, I am marking it as degraded. This is done in the status monitor app only once per five-minute interval. 

Screen shots here:

<img width="847" alt="Screen Shot 2020-02-01 at 6 54 55 PM" src="https://user-images.githubusercontent.com/5296416/73601301-b9689700-4524-11ea-99f1-aa9fc8d884a8.png">

<img width="496" alt="Screen Shot 2020-02-01 at 6 55 00 PM" src="https://user-images.githubusercontent.com/5296416/73601303-bd94b480-4524-11ea-807c-87183aed1d1f.png">

@conda-forge/core for viz and any comments!

closes #67 
