### PR TITLE
add status monitor for open-gpu-server

### DIFF
--- a/site/open-gpu-server.js
+++ b/site/open-gpu-server.js
@@ -1,0 +1,29 @@
+function loadOpenStatusJSON (url, callback) {
+  var xobj = new XMLHttpRequest()
+  xobj.overrideMimeType('application/json')
+  xobj.open('GET', url, true)
+  xobj.onreadystatechange = function () {
+    if (xobj.readyState === 4 && xobj.status === 200) {
+      // Required use of an anonymous callback as .open will NOT return a value
+      // but simply returns undefined in asynchronous mode
+      callback(xobj.responseText)
+    }
+  }
+  xobj.send(null)
+}
+
+function displayOpenGPUServerStatus (reportText) {
+  var report = JSON.parse(reportText)
+  var div = document.getElementById('open-gpu-server-status')
+  
+  if (report.status === 'operational') {
+      div.className = 'status operational'
+      div.innerHTML = 'All Systems Operational'
+  } else {
+      div.className = 'status degraded performance'
+      div.innerHTML = report.status
+  }
+}
+
+var url = 'https://api.openstatus.dev/public/status/open-gpu-server'
+loadOpenStatusJSON(url, displayOpenGPUServerStatus)

--- a/site/template.html
+++ b/site/template.html
@@ -207,6 +207,10 @@
           <h5><a href="https://status.dev.azure.com/">Azure DevOps</a>: <span id="azure-status">No Status Available</span></h5>
         </div>
         <script type="text/javascript" src="azure.js"></script>
+        <div id="open-gpu-server-dummy-div">
+          <h5><a href="https://ci-status.quansight.dev/">Open GPU Server</a>: <span id="open-gpu-server-status">No Status Available</span></h5>
+        </div>
+        <script type="text/javascript" src="open-gpu-server.js"></script>
 
         <h4 id="little_migrations"><a href="#other_migrations" style="color: inherit;">Short-Term Migrations</a></h4>
         <div id="migratorDivLittle" style="text-align:center;"></div>


### PR DESCRIPTION
Adds a status monitor for `open-gpu-server` based on the [public API](https://docs.openstatus.dev/getting-started/status-widget) for https://open-gpu-server.openstatus.dev/.

This might be protected by CORS, so there's a chance it doesn't work on Github Pages. Locally, I could only make it to work via https://cors-anywhere.herokuapp.com/. 

If it doesn't work, we'll cache the response in the conda-forge-webservices like we do with Azure.