### PR TITLE
fix timezone awareness

### DIFF
--- a/render_page.py
+++ b/render_page.py
@@ -14,7 +14,7 @@ BAD_LABELS = set([
     'major outage',
     'maintenance'
 ])
-OLDEST = datetime.datetime.utcnow() - datetime.timedelta(days=90)
+OLDEST = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(days=90)
 TIME_FMT = '%Y/%m/%d %H:%M:%S'
 
 gh = Github(os.environ['GITHUB_TOKEN'])


### PR DESCRIPTION
Current failures in CI:

```
Traceback (most recent call last):
  File "/home/runner/work/status/status/render_page.py", line 48, in <module>
    if issue.closed_at > OLDEST:
TypeError: can't compare offset-naive and offset-aware datetimes
```
