### PR TITLE
use open-gpu-server monitor proxy from the webservices

### DIFF
--- a/site/open-gpu-server.js
+++ b/site/open-gpu-server.js
@@ -25,5 +25,5 @@ function displayOpenGPUServerStatus (reportText) {
   }
 }
 
-var url = 'https://api.openstatus.dev/public/status/open-gpu-server'
+var url = 'https://conda-forge.herokuapp.com/status-monitor/open-gpu-server'
 loadOpenStatusJSON(url, displayOpenGPUServerStatus)


### PR DESCRIPTION
Fixes CORS issue in https://github.com/conda-forge/status/pull/161 by using endpoint added at https://github.com/conda-forge/conda-forge-webservices/pull/570
