### PR TITLE
Disable GHA workflow for now

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   deploy:
+    if: false
     runs-on: ubuntu-latest
     steps:
     - name: checkout


### PR DESCRIPTION
Preparing for the merge of https://github.com/conda-forge/conda-forge.github.io/pull/2090

Disabling the workflow so it doesn't regenerate the gh-pages branch, which seems to reenable the GH Pages feature in Settings.